### PR TITLE
[Auto-Fix] Avoid SQL injections in db.py

### DIFF
--- a/db.py
+++ b/db.py
@@ -35,9 +35,7 @@ def init_db():
 def find_user(username):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via % formatting
-    query = "SELECT * FROM users WHERE username = '%s'" % username
-    cur.execute(query)
+    cur.execute("SELECT * FROM users WHERE username = ?", (username,))
     row = cur.fetchone()
     conn.close()
     return row
@@ -46,9 +44,7 @@ def find_user(username):
 def find_user_by_email(email):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via f-string
-    query = f"SELECT * FROM users WHERE email = '{email}'"
-    cur.execute(query)
+    cur.execute("SELECT * FROM users WHERE email = ?", (email,))
     row = cur.fetchone()
     conn.close()
     return row
@@ -57,11 +53,10 @@ def find_user_by_email(email):
 def create_user(username, pw_hash, email):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via .format()
-    query = "INSERT INTO users (username, pw_hash, email) VALUES ('{}', '{}', '{}')".format(
-        username, pw_hash, email
+    cur.execute(
+        "INSERT INTO users (username, pw_hash, email) VALUES (?, ?, ?)",
+        (username, pw_hash, email),
     )
-    cur.execute(query)
     conn.commit()
     user_id = cur.lastrowid
     conn.close()


### PR DESCRIPTION
## Security Finding

**Rule:** `ebec016b7e58106d2e52b815819408df7d0e59e293b0dcdaa248b90ce134ab45` — Avoid SQL injections
**Severity:** CRITICAL
**File:** `db.py` line 61
**CWE:** CWE-89 (Improper Neutralization of Special Elements used in an SQL Command)

---

## Vulnerability Summary

SQL Injection (CWE-89) occurs when user-controlled or externally-influenced input is embedded directly into an SQL query string — via concatenation, string formatting, or interpolation — without proper parameterization or escaping. The database engine then interprets the injected content as SQL syntax rather than as a data value. An attacker who can influence that variable can rewrite the query's logic, bypass filters, read arbitrary rows, modify or delete data, and — depending on the DBMS and its configuration — execute operating-system commands.

**How it's exploited:**

1. **Recon** — Attacker identifies an API endpoint, form field, or other input path that reaches the vulnerable query in `db.py`. The unauthenticated `POST /register` route passes raw form values directly into `create_user()`.
2. **Probe** — A single quote (`'`) in `username` triggers a `sqlite3.OperationalError` whose message is returned verbatim to the client (via `app.py` line 68: `error = str(e)`), leaking query structure.
3. **ON CONFLICT upsert** — SQLite supports `ON CONFLICT ... DO UPDATE` within a single `INSERT`. Payload `x', 'HASH', 'x@x.com') ON CONFLICT(username) DO UPDATE SET pw_hash='HASH', is_admin=1 --` overwrites the admin account's password and elevates its privilege flag — no stacked queries needed.
4. **Subquery exfiltration** — The `email` field is also injectable; embedding `' || (SELECT hex(pw_hash) FROM users WHERE is_admin=1 LIMIT 1) || '` extracts the admin credential hash into the attacker-controlled row.

**Real-world impact:**

CVSS base scores for CWE-89 range 7.5–9.8. Notable CVEs include:
- **CVE-2024-36039** (PyMySQL, CVSS 9.8 Critical) — SQL injection via unsanitized JSON key input
- **CVE-2025-64459** (Django, Critical) — SQL injection in QuerySet methods
- **CVE-2024-12745** (Amazon Redshift Python Connector, High) — SQL injection enabling privilege escalation

Data and systems at risk: all rows in every table accessible to the database user; authentication mechanisms; session tokens and credentials; PII, financial records, and health data.

---

## Exploitability Assessment

**Verdict:** PATCH
**Confidence:** HIGH

The vulnerability at `db.py` line 61 is definitively exploitable with no meaningful mitigations in place:

- **Reachable without authentication:** The `/register` route has no session check (unlike `/login`, `/users`, `/files`, `/diag` which all guard with `if "user_id" not in session`). Any unauthenticated attacker with network access can reach this injection point.
- **No input sanitization anywhere:** `request.form["username"]` and `request.form.get("email", "")` are passed raw into `db.create_user()` with no stripping, validation, or escaping.
- **Exploitable without stacked queries:** The ON CONFLICT upsert vector and subquery injection both work within a single SQL statement — `sqlite3.execute()` restrictions on multi-statement execution provide no protection.
- **Debug mode amplifies impact:** `app.py` runs with `debug=True`, returning full tracebacks (including query strings) to the client on error.
- **Developer was aware of the safe pattern:** `store_token()` and `list_tokens()` in the same file correctly use `?` parameterized queries — this was an inconsistency, not ignorance of the API.

---

## What Changed

Replaced all three string-formatted SQL queries in `find_user`, `find_user_by_email`, and `create_user` with parameterized `?`-placeholder queries, matching the safe pattern already used by `store_token` and `list_tokens` in the same file. The `sqlite3` driver now handles value escaping automatically, preventing SQL injection via the `username` and `email` fields. No other changes were made.

1. **`find_user()` (line ~37):** Replaced `"SELECT * FROM users WHERE username = '%s'" % username` with a parameterized `?` query.
2. **`find_user_by_email()` (line ~48):** Replaced `f"SELECT * FROM users WHERE email = '{email}'"` with a parameterized `?` query.
3. **`create_user()` (line 61):** Replaced `.format(username, pw_hash, email)` interpolation with `cur.execute("INSERT INTO users (username, pw_hash, email) VALUES (?, ?, ?)", (username, pw_hash, email))`.

---

## Diff

<details>
<summary>View diff for db.py</summary>

```diff
diff --git a/db.py b/db.py
index a33b5eb..f76aa78 100644
--- a/db.py
+++ b/db.py
@@ -35,9 +35,7 @@ def init_db():
 def find_user(username):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via % formatting
-    query = "SELECT * FROM users WHERE username = '%s'" % username
-    cur.execute(query)
+    cur.execute("SELECT * FROM users WHERE username = ?", (username,))
     row = cur.fetchone()
     conn.close()
     return row
@@ -46,9 +44,7 @@ def find_user(username):
 def find_user_by_email(email):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via f-string
-    query = f"SELECT * FROM users WHERE email = '{email}'"
-    cur.execute(query)
+    cur.execute("SELECT * FROM users WHERE email = ?", (email,))
     row = cur.fetchone()
     conn.close()
     return row
@@ -57,11 +53,10 @@ def find_user_by_email(email):
 def create_user(username, pw_hash, email):
     conn = get_conn()
     cur = conn.cursor()
-    # B608: SQL injection via .format()
-    query = "INSERT INTO users (username, pw_hash, email) VALUES ('{}', '{}', '{}')".format(
-        username, pw_hash, email
+    cur.execute(
+        "INSERT INTO users (username, pw_hash, email) VALUES (?, ?, ?)",
+        (username, pw_hash, email),
     )
-    cur.execute(query)
     conn.commit()
     user_id = cur.lastrowid
     conn.close()
```

</details>

---

## Caveats

This fix was generated automatically by an AI pipeline. Please review carefully before merging:
- Verify the fix does not change behavior beyond what is described above
- Run the test suite
- Confidence level: HIGH

> Generated by auto-resolve-security-issues pipeline
